### PR TITLE
BUGFIX-3: Autoloading of services doesn't work if using 'required'

### DIFF
--- a/app/services/para_listener.rb
+++ b/app/services/para_listener.rb
@@ -1,4 +1,5 @@
-require 'para_element'
+require_dependency 'para_element'
+
 class ParaListener
 	def initialize
 		@data = []


### PR DESCRIPTION
Switched to the "require_dependency 'para_element' " fixes #3.
